### PR TITLE
UI Tweaks for Inventory Items

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -185,6 +185,23 @@ def main():
     edit.add_invoke_entry('ClientFeatureKnobBundle_getEnableNewHackAnimations', 'v0', 'v0')
     edit.save()
 
+    #stop inventory item rotation
+    edit = edit_cls('InventoryItemRenderer')
+    edit.prepare_after_prologue('rotate')
+    edit.add_invoke_entry('InventoryItemRenderer_shouldRotate', ret='v0')
+    edit.add_ret_if_result(False, 'result')
+    edit.save()
+
+    #simplify inventory item rendering
+    edit = edit_cls('InventoryItemRenderer')
+    edit.find_line('.*Lcom/badlogic/gdx/graphics/glutils/ShaderProgram;->end.*')
+    edit.prepare_to_insert()
+    edit.add_invoke_entry('InventoryItemRenderer_simplifyItems', ret='v0')
+    edit.add_line('if-nez v0, :skip_item_shader')
+    edit.find_line('.*Lcom/badlogic/gdx/graphics/glutils/ShaderProgram;->end.*', where='down')
+    edit.prepare_to_insert()
+    edit.add_line(':skip_item_shader')
+    edit.save()
 
 if __name__ == '__main__':
     main()

--- a/res/analyzer.yaml
+++ b/res/analyzer.yaml
@@ -28,6 +28,8 @@ broot.ingress.mod.Entry:
     PortalUpgrade_onDispose: [null, V]
     PortalUpgrade_getResonatorBrowserHeight: [null, I, I]
     ClientFeatureKnobBundle_getEnableNewHackAnimations: [null, Z, Z]
+    InventoryItemRenderer_shouldRotate: [null, Z]
+    InventoryItemRenderer_simplifyItems: [null, Z]
 
     getClientType: [null, $ClientType]
     getClientTypeForJackson: [null, $ClientType]
@@ -417,6 +419,13 @@ com.nianticproject.ingress.common.inventory.ui.ItemDisplayNameUtils:
     getDisplayDescription: [b, $GameEntity]
 
   find_by_string: 'Not a resource: %s'
+
+com.nianticproject.ingress.common.inventory.ui.InventoryItemRenderer:
+  methods:
+    rotate: [a, Z, F]
+
+  obf_name: com.nianticproject.ingress.common.inventory.ui.ar
+
 
 com.nianticproject.ingress.common.inventory.ui.IndistinguishableItems:
   methods:

--- a/src/broot/ingress/mod/AboutModActivity.java
+++ b/src/broot/ingress/mod/AboutModActivity.java
@@ -115,6 +115,13 @@ public class AboutModActivity extends BaseSubActivity {
                         updateAnimsValues(true);
                     }
                 });
+                animsItem.addButton("Item rotation", "", new ClickListener() {
+                    @Override
+                    public void clicked(InputEvent event, float x, float y) {
+                        Config.rotateInventoryItemsEnabled = !Config.rotateInventoryItemsEnabled;
+                        updateAnimsValues(true);
+                    }
+                });
                 addItem(animsItem);
 
                 uiTweaksItem = new ListItem(skin, "UI tweaks", null);
@@ -146,6 +153,13 @@ public class AboutModActivity extends BaseSubActivity {
                     @Override
                     public void clicked(InputEvent event, float x, float y) {
                         Config.scannerObjectsEnabled = !Config.scannerObjectsEnabled;
+                        updateUiTweaksValues(true);
+                    }
+                });
+                uiTweaksItem.addButton("Simplify Items", "", new ClickListener() {
+                    @Override
+                    public void clicked(InputEvent event, float x, float y) {
+                        Config.simplifyInventoryItems = !Config.simplifyInventoryItems;
                         updateUiTweaksValues(true);
                     }
                 });
@@ -233,6 +247,7 @@ public class AboutModActivity extends BaseSubActivity {
         animsItem.buttons.get(0).setText(!Config.skipIntro ? "ON" : "OFF");
         animsItem.buttons.get(1).setText(Config.scannerZoomInAnimEnabled ? "ON" : "OFF");
         animsItem.buttons.get(2).setText(Config.newHackAnimEnabled ? "ON" : "OFF");
+        animsItem.buttons.get(3).setText(Config.rotateInventoryItemsEnabled ? "ON" : "OFF");
     }
 
     private void updateUiTweaksValues(boolean save) {
@@ -243,6 +258,7 @@ public class AboutModActivity extends BaseSubActivity {
         uiTweaksItem.buttons.get(1).setText(Config.showPortalVectors ? "ON" : "OFF");
         uiTweaksItem.buttons.get(2).setText(Config.portalParticlesEnabled ? "ON" : "OFF");
         uiTweaksItem.buttons.get(3).setText(Config.scannerObjectsEnabled ? "ON" : "OFF");
+        uiTweaksItem.buttons.get(4).setText(Config.simplifyInventoryItems ? "ON" : "OFF");
     }
 
     private void updateUiVariantValue() {

--- a/src/broot/ingress/mod/Entry.java
+++ b/src/broot/ingress/mod/Entry.java
@@ -179,6 +179,14 @@ public class Entry {
         return orig && Config.newHackAnimEnabled;
     }
 
+    public static boolean InventoryItemRenderer_shouldRotate() {
+        return Config.rotateInventoryItemsEnabled;
+    }
+
+    public static boolean InventoryItemRenderer_simplifyItems() {
+        return Config.simplifyInventoryItems;
+    }
+
     public static ClientType getClientType() {
         return ClientType.DEVELOPMENT;
     }

--- a/src/broot/ingress/mod/util/Config.java
+++ b/src/broot/ingress/mod/util/Config.java
@@ -19,12 +19,14 @@ public class Config {
     public static boolean skipIntro;
     public static boolean scannerZoomInAnimEnabled;
     public static boolean newHackAnimEnabled;
+    public static boolean rotateInventoryItemsEnabled;
 
     public static boolean fullscreen;
     public static boolean showPortalVectors;
     public static boolean portalParticlesEnabled;
     public static boolean xmGlobsEnabled;
     public static boolean scannerObjectsEnabled;
+    public static boolean simplifyInventoryItems;
 
     public static UiVariant uiVariant;
 
@@ -43,12 +45,14 @@ public class Config {
         skipIntro = prefs.getBoolean("skipIntro", false);
         scannerZoomInAnimEnabled = prefs.getBoolean("scannerZoomInAnimEnabled", true);
         newHackAnimEnabled = prefs.getBoolean("newHackAnimEnabled", true);
+        rotateInventoryItemsEnabled = prefs.getBoolean("rotateInventoryItemsEnabled", true);
 
         fullscreen = prefs.getBoolean("fullscreen", false);
         showPortalVectors = prefs.getBoolean("showPortalVectors", true);
         portalParticlesEnabled = prefs.getBoolean("portalParticlesEnabled", true);
         xmGlobsEnabled = prefs.getBoolean("xmGlobsEnabled", true);
         scannerObjectsEnabled = prefs.getBoolean("scannerObjectsEnabled", true);
+        simplifyInventoryItems = prefs.getBoolean("simplifyInventoryItems", false);
 
         uiVariant = UiVariant.byName.get(prefs.getString("uiVariant", "auto"));
         if (uiVariant == null) {
@@ -73,12 +77,14 @@ public class Config {
         e.putBoolean("skipIntro", skipIntro);
         e.putBoolean("scannerZoomInAnimEnabled", scannerZoomInAnimEnabled);
         e.putBoolean("newHackAnimEnabled", newHackAnimEnabled);
+        e.putBoolean("rotateInventoryItemsEnabled", rotateInventoryItemsEnabled);
 
         e.putBoolean("fullscreen", fullscreen);
         e.putBoolean("showPortalVectors", showPortalVectors);
         e.putBoolean("portalParticlesEnabled", portalParticlesEnabled);
         e.putBoolean("xmGlobsEnabled", xmGlobsEnabled);
         e.putBoolean("scannerObjectsEnabled", scannerObjectsEnabled);
+        e.putBoolean("simplifyInventoryItems", scannerObjectsEnabled);
 
         e.putString("uiVariant", uiVariant.name);
 


### PR DESCRIPTION
This changes add two new options to the MOD menu. The first disables the rotation of items in the inventory. The 2nd simplifies the rendering of the items in the inventory to save computation time.
